### PR TITLE
Fix markdown in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h3 align="center">
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
-	Catppuccin for <a href="https://github.com/catppuccin/enmity">Enmity</a>
+	Catppuccin for <a href="https://enmity.app/">Enmity</a>
   
 
 </h3>


### PR DESCRIPTION
the enmity link just links recursively to catppuccin/enmity, it should link to the enmity site or github 
if this is for a reason feel free to ignore