### PR TITLE
Fixed "normal text"

### DIFF
--- a/themes/Mocha.json
+++ b/themes/Mocha.json
@@ -85,7 +85,7 @@
 		"TEXT_LINK": ["#b4befe", "#b4befe"],
 		"TEXT_LINK_LOW_SATURATION": ["#cdd6f4", "#cdd6f4"],
 		"TEXT_MUTED": ["#6c7086", "#6c7086"],
-		"TEXT_NORMAL": ["#9399b2", "#9399b2"],
+		"TEXT_NORMAL": ["#cdd6f4", "#cdd6f4"],
 		"TEXT_POSITIVE": ["#a6e3a1", "#a6e3a1"],
 		"TEXT_WARNING": ["#f38ba8", "#f38ba8"]
 		},


### PR DESCRIPTION
The main text color looked like it was a "muted" text. The official ctp discord theme also uses this color code for the "normal" text, so I changed it.

Example for what it would look like now:
![image](https://user-images.githubusercontent.com/73737531/212745978-f51b0491-b941-4cd9-909c-84ac8859aebe.png)


